### PR TITLE
Specify graph_nets==1.0.5

### DIFF
--- a/gnn-tracking/setup.py
+++ b/gnn-tracking/setup.py
@@ -19,7 +19,7 @@ setup(
     url="https://github.com/exatrkx/exatrkx-work",
     packages=find_packages(),
     install_requires=[
-        "graph_nets",
+        "graph_nets==1.0.5",
         'tensorflow-gpu<2',
         'gast==0.2.2',
         "future",


### PR DESCRIPTION
Specify graph_nets==1.0.5 (which requires dm-sonnet<2), othertwise dm-sonnet==2.0.0 is installed (and GNN models don't work)